### PR TITLE
Add Ember imports from ember-inflector

### DIFF
--- a/plugin/emberimports.vim
+++ b/plugin/emberimports.vim
@@ -247,6 +247,8 @@ call JSAddImportDefinition({'name': 'belongsTo', 'default': 0, 'from': 'ember-da
 call JSAddImportDefinition({'name': 'hasMany', 'default': 0, 'from': 'ember-data'})
 call JSAddImportDefinition({'name': 'Relationship', 'default': 0, 'from': 'ember-data'})
 call JSAddImportDefinition({'name': 'hbs', 'default': 1, 'from': 'htmlbars-inline-precompile'})
+call JSAddImportDefinition({'name': 'singularize', 'default': 0, 'from': 'ember-inflector'})
+call JSAddImportDefinition({'name': 'pluralize', 'default': 0, 'from': 'ember-inflector'})
 
 if exists("g:ember_imports_ember_data_next")
   call JSAddImportDefinition({'name': 'Model', 'default': 1, 'from': 'ember-data/model'})


### PR DESCRIPTION
When working with custom serializers I found myself using `singularize`
quite a bit and not being able to import it using the command got
annyoing.

This adds imports for `singularize` and `pluralize` from the
`ember-inflector` package.

Defined in https://github.com/emberjs/ember-inflector/blob/c42de2e29c47d9c8ac6e25635e6483ca87bad9b3/addon/index.js